### PR TITLE
remove ember-data from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.6.0",
-    "ember-data": "^3.3.0"
+    "ember-cli-babel": "^6.6.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.7.0",


### PR DESCRIPTION
I don't think we should force consuming apps to use a specific ember-data version.
Or at least relax the version that is required.